### PR TITLE
Wrap variable value in a spec dataclass to carry unit.

### DIFF
--- a/documentation/docs/developer-guide/adrs.md
+++ b/documentation/docs/developer-guide/adrs.md
@@ -168,3 +168,4 @@ scicat_json_to_yaml --input-file PATH/TO/THE/JSON/FILE
 ```
 
 It can be used for any configuration or schema files.
+

--- a/documentation/docs/developer-guide/adrs.md
+++ b/documentation/docs/developer-guide/adrs.md
@@ -168,4 +168,3 @@ scicat_json_to_yaml --input-file PATH/TO/THE/JSON/FILE
 ```
 
 It can be used for any configuration or schema files.
-

--- a/src/scicat_offline_ingestor.py
+++ b/src/scicat_offline_ingestor.py
@@ -30,7 +30,11 @@ from scicat_dataset import (
     scicat_dataset_to_dict,
 )
 from scicat_logging import build_logger
-from scicat_metadata import collect_schemas, select_applicable_schema
+from scicat_metadata import (
+    MetadataVariableValueSpec,
+    collect_schemas,
+    select_applicable_schema,
+)
 from scicat_path_helpers import compose_ingestor_directory
 from system_helpers import exit, handle_exceptions
 
@@ -116,6 +120,14 @@ def _check_if_dataset_exists_by_metadata(
     return False
 
 
+def _retrieve_source_folder(
+    variable_map: dict[str, MetadataVariableValueSpec],
+) -> str | None:
+    """Retrieve the source folder from the variable map."""
+    value = variable_map.get("source_folder", None)
+    return value.value if isinstance(value, MetadataVariableValueSpec) else None
+
+
 def main() -> None:
     """Main entry point of the app."""
     tmp_config = build_offline_config()
@@ -159,7 +171,7 @@ def main() -> None:
             nexus_file=nexus_file_path,
             ingestor_directory=ingestor_directory,
             config=fh_options,
-            source_folder=variable_map["source_folder"],
+            source_folder=_retrieve_source_folder(variable_map),
             logger=logger,
             # TODO: add done_writing_message_file and nexus_structure_file
         )

--- a/tests/resources/example_schema.imsc.yml
+++ b/tests/resources/example_schema.imsc.yml
@@ -1,0 +1,115 @@
+order: 1
+id: supposedly-long-uuid
+name: Metadata Schema For Testing
+instrument: scicat-ingestor
+selector: ''
+variables:
+  # NXS variables
+  pid:
+    source: NXS
+    path: /entry/entry_identifier_uuid
+    value_type: string
+  proposal_id:
+    source: NXS
+    path: /entry/experiment_identifier
+    value_type: string
+  instrument_name:
+    source: NXS
+    path: /entry/instrument/name
+    value_type: string
+  detector_names_all:
+    source: NXS
+    path: /entry/instrument/detectors/*/name
+    value_type: string[]
+  detector_names_list:
+    source: NXS
+    path: /entry/instrument/detectors/detector_*/name
+    value_type: string[]
+  sample_temperature:
+    source: NXS
+    path: /entry/sample/temperature
+    value_type: float
+  # VALUE type variables
+  detector_names:
+    source: VALUE
+    operator: join_with_space
+    value: <detector_names_list>
+    value_type: string
+  access_groups:
+    source: VALUE
+    value:
+    - dmsc-staff
+    - ess_proposal_<proposal_id>
+    value_type: string[]
+schema:
+  pid:
+    field_type: high_level
+    machine_name: pid
+    value: <pid>
+    type: string
+  proposal_id:
+    field_type: high_level
+    machine_name: proposalId
+    value: <proposal_id>
+    type: string
+  detector_names:
+    field_type: scientific_metadata
+    machine_name: detector_names
+    human_name: Detector Names
+    value: <detector_names>
+    type: string
+  sample_temperature:
+    field_type: scientific_metadata
+    machine_name: sample_temperature
+    human_name: Sample Temperature
+    value: <sample_temperature>
+    type: string
+  # Mandatory schema items (machine name)
+  source_folder:
+    field_type: high_level
+    machine_name: sourceFolder
+    human_name: Source Folder
+    value: ''
+    type: string
+  principal_investigator:
+    field_type: high_level
+    machine_name: principalInvestigator
+    human_name: Principal Investigator
+    value: ''
+    type: string
+  owner:
+    field_type: high_level
+    machine_name: owner
+    human_name: Owner
+    value: ''
+    type: string
+  creation_location:
+    field_type: high_level
+    machine_name: creationLocation
+    human_name: Creation Location
+    value: ''
+    type: string
+  creation_time:
+    field_type: high_level
+    machine_name: creationTime
+    human_name: Creation Time
+    value: ''
+    type: string
+  owner_email:
+    field_type: high_level
+    machine_name: ownerEmail
+    human_name: Owner Email
+    value: ''
+    type: string
+  dataset_name:
+    field_type: high_level
+    machine_name: datasetName
+    human_name: Dataset Name
+    value: ''
+    type: string
+  contact_email:
+    field_type: high_level
+    machine_name: contactEmail
+    human_name: Contact Email
+    value: ''
+    type: string


### PR DESCRIPTION
Fixes #161 

It needed some invasive updates across many places to 
 - retrieve unit as early as possible
 - allow hard-coding unit in the schema definition files
 - allow value operator to process unit as well

This time I added a few unit tests using example schema and nexus file.
I didn't add stubbed test using scicat but if it causes problem later, we can add stubbed unit test or an integration test later.

I also noticed that some mandatory fields in `ScicatDataset` dataclass rely on the schema definitions,
so I added them in the validation function.